### PR TITLE
Fix BufferedWriteStream to fix broken AGS savefile creation on Switch

### DIFF
--- a/common/stream.cpp
+++ b/common/stream.cpp
@@ -550,7 +550,7 @@ public:
 
 	bool flush() override { return flushBuffer(); }
 
-	int64 pos() const override { return _pos; }
+	int64 pos() const override { return _pos + _parentStream->pos(); }
 
 	bool seek(int64 offset, int whence) override {
 		flush();


### PR DESCRIPTION
At the moment saving the game in AGS engine is broken on Nintendo Switch, the created save files are invalid and cannot be loaded. The proposed patch fixes the root cause of the problem: the Switch port uses BufferedWriteStream wrapper for savefile streams, but AGS saving routine uses tell() (currently broken) and seek().